### PR TITLE
Update documentation to reflect automatic URL transformation for loca…

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -95,7 +95,7 @@ After startup, the following services are available:
 
 ## Example Scans
 
-### Host Gateway Version
+### Automatic URL Transformation
 ```bash
 # Test ZAP API directly
 curl http://localhost:8080/JSON/core/view/version/
@@ -103,9 +103,23 @@ curl http://localhost:8080/JSON/core/view/version/
 # Test MCP Server
 curl http://localhost:8082/mcp
 
-# ⚠️ CRITICAL: Scan localhost app (MUST use host.docker.internal)
-# ❌ WRONG: http://localhost:3000
-# ✅ CORRECT: http://host.docker.internal:3000
+# ✅ AUTOMATIC: Scan localhost app (URLs are automatically transformed)
+# ✅ CORRECT: http://localhost:3000 (automatically becomes http://host.docker.internal:3000)
+# ✅ CORRECT: http://127.0.0.1:8080 (automatically becomes http://host.docker.internal:8080)
+```
+
+### Example with OWASP Juice Shop
+```bash
+# Scan OWASP Juice Shop (publicly available test target)
+curl -X POST http://localhost:8082/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool": "start_complete_scan",
+    "arguments": {
+      "url": "https://juice-shop.herokuapp.com/#/",
+      "include_findings": true
+    }
+  }'
 ```
 
 ## Troubleshooting
@@ -132,20 +146,20 @@ curl http://localhost:8080/JSON/core/view/version/
 
 ### Localhost Access Doesn't Work
 
-**⚠️ MOST COMMON ISSUE: Using `localhost` instead of `host.docker.internal`**
+**✅ AUTOMATIC TRANSFORMATION:** The server automatically transforms `localhost` URLs to `host.docker.internal`. If you're still having issues:
 
 ```bash
 # ✅ CORRECT: Check if host.docker.internal is reachable
 docker-compose exec zap-mcp curl http://host.docker.internal:3000
 
-# ❌ WRONG: This will NOT work from inside the container
+# ✅ ALSO CORRECT: Use localhost (automatically transformed)
 docker-compose exec zap-mcp curl http://localhost:3000
 
 # If host.docker.internal doesn't work, try host IP address
 docker-compose exec zap-mcp curl http://172.17.0.1:3000
 ```
 
-**Remember: You MUST use `host.docker.internal`, never `localhost`!**
+**The server automatically handles URL transformation - you can use `localhost` URLs directly!**
 
 ### Port Conflicts
 
@@ -228,7 +242,7 @@ docker-compose up -d
 
 | Solution | Advantages | Disadvantages | Recommendation |
 |----------|------------|---------------|----------------|
-| Host Gateway | Secure, isolated, flexible | URL transformation needed | ✅ **Recommended** |
+| Host Gateway | Secure, isolated, flexible | None (automatic URL transformation) | ✅ **Recommended** |
 
 ## Usage with MCP Clients
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A powerful **Model Context Protocol (MCP) Server** that integrates **OWASP ZAP**
 - **📊 Rich Reporting**: Detailed vulnerability reports with risk scoring
 - **🔄 Session Management**: Flexible session handling strategies
 - **🛡️ Production Ready**: Robust error handling and logging
+- **🔄 Automatic URL Transformation**: Automatically maps `localhost` URLs to container host gateways
 
 ## 📋 Prerequisites
 
@@ -173,7 +174,7 @@ start.bat
 - **[DOCKER.md](DOCKER.md)** - Complete Docker guide
 - **[PODMAN.md](PODMAN.md)** - Complete Podman guide
 
-**⚠️ CRITICAL:** For localhost scanning, use `host.docker.internal` (Docker) or `host.containers.internal` (Podman) instead of `localhost`. This is the **only supported method**.
+**✅ AUTOMATIC URL TRANSFORMATION:** The server automatically detects Docker/Podman environments and transforms `localhost`/`127.0.0.1` URLs to the appropriate host gateway. You can use `localhost` URLs directly - no manual mapping needed!
 
 ### 💻 Local Installation
 
@@ -271,17 +272,38 @@ For other MCP clients, use the same URL endpoint.
 }
 ```
 
+### Localhost Scanning Examples
+
+**✅ AUTOMATIC URL TRANSFORMATION:** The server automatically detects Docker/Podman environments and transforms `localhost`/`127.0.0.1` URLs:
+
+```json
+{
+  "tool": "start_complete_scan",
+  "arguments": {
+    "url": "http://localhost:3000",
+    "include_findings": true
+  }
+}
+```
+
+**What happens automatically:**
+- **Docker**: `http://localhost:3000` → `http://host.docker.internal:3000`
+- **Podman**: `http://localhost:3000` → `http://host.containers.internal:3000`
+- **Local**: `http://localhost:3000` → `http://localhost:3000` (unchanged)
+
 **📖 For Docker/Podman localhost scanning examples, see:**
 - **[DOCKER.md](DOCKER.md)** - Docker localhost examples
 - **[PODMAN.md](PODMAN.md)** - Podman localhost examples
 
 ### Basic Security Scan
 
+**💡 Example Target:** [OWASP Juice Shop](https://juice-shop.herokuapp.com/#/) - A deliberately vulnerable web application designed for security testing and training.
+
 ```json
 {
   "tool": "start_complete_scan",
   "arguments": {
-    "url": "https://example.com",
+    "url": "https://juice-shop.herokuapp.com/#/",
     "include_findings": true,
     "include_evidence": false
   }
@@ -290,11 +312,13 @@ For other MCP clients, use the same URL endpoint.
 
 ### Quick Passive Scan
 
+**💡 Perfect for:** Quick security assessment without active testing.
+
 ```json
 {
   "tool": "start_passive_scan",
   "arguments": {
-    "url": "https://example.com",
+    "url": "https://juice-shop.herokuapp.com/#/",
     "timeout_seconds": 300
   }
 }
@@ -302,11 +326,13 @@ For other MCP clients, use the same URL endpoint.
 
 ### Custom Active Scan
 
+**💡 Advanced configuration:** Custom timeouts and scan policies for thorough testing.
+
 ```json
 {
   "tool": "start_active_scan",
   "arguments": {
-    "url": "https://example.com",
+    "url": "https://juice-shop.herokuapp.com/#/",
     "ascan_max_wait_seconds": 3600,
     "spider_max_wait_seconds": 900,
     "scanPolicyName": "Default Policy"
@@ -352,9 +378,11 @@ For other MCP clients, use the same URL endpoint.
 
 ## 🐳 Container Deployment
 
+**✅ AUTOMATIC URL TRANSFORMATION:** The server automatically detects Docker/Podman environments and transforms `localhost`/`127.0.0.1` URLs to the appropriate host gateway. You can use `localhost` URLs directly!
+
 **📖 For complete container setup and usage instructions, see:**
-- **[DOCKER.md](DOCKER.md)** - Complete Docker setup guide with localhost scanning
-- **[PODMAN.md](PODMAN.md)** - Complete Podman setup guide with localhost scanning
+- **[DOCKER.md](DOCKER.md)** - Complete Docker setup guide with automatic URL transformation
+- **[PODMAN.md](PODMAN.md)** - Complete Podman setup guide with automatic URL transformation
 
 **Quick container commands:**
 ```bash
@@ -381,7 +409,7 @@ Scans return structured results including:
 ```json
 {
   "scan_id": "abc12345",
-  "target": "https://example.com",
+  "target": "https://juice-shop.herokuapp.com/#/",
   "alerts": {
     "High": 2,
     "Medium": 5,


### PR DESCRIPTION
…lhost in Docker and Podman

- Changed references from `localhost` to `automatic URL transformation` in DOCKER.md and PODMAN.md.
- Added examples demonstrating the automatic mapping of `localhost` URLs to the appropriate host gateways.
- Updated README.md to highlight the new feature and its benefits for users.